### PR TITLE
[BUGFIX] fix default page ID in pageTree retrieval

### DIFF
--- a/Classes/Controller/BackendModerateCommentsController.php
+++ b/Classes/Controller/BackendModerateCommentsController.php
@@ -48,7 +48,7 @@ class BackendModerateCommentsController extends ActionController
     {
         $pageId = $this->getCurrentPageId();
         $depth = (int)$this->formValueProvider->getStoredValue($this->request->getPluginName(), 'depth');
-        $pageTree = $this->pageProvider->getPageTree($pageId ?? 0, $depth);
+        $pageTree = $this->pageProvider->getPageTree($pageId ?? 1, $depth);
         $moduleTemplate = $this->moduleTemplateFactory->create($this->request);
         $uidList = PagetreeUtility::getPageIdArray($pageTree);
 


### PR DESCRIPTION
Adjusted the fallback page ID from 0 to 1 when retrieving the page tree. This ensures proper behavior when no valid page ID is provided since a page with id 0 does never exist.